### PR TITLE
Skip Wordpress checking unless hash starts with '$P$'

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -35,6 +35,7 @@ require 'digest'
     end
 
     def check(pw, hash)
+      return false unless hash.start_with?('$P$')
       crypt(pw, hash) == hash
     end
 


### PR DESCRIPTION
When checking some hashes created using different algorithms, crypt() would take a long time if the 4th character of the hash was certain values. Skip checking altogether for these hashes by checking for $P$ at the start of the hash.