### PR TITLE
Add support for Joomla passwords

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -35,7 +35,6 @@ require 'digest'
     end
 
     def check(pw, hash)
-      return false unless hash.start_with?('$P$')
       crypt(pw, hash) == hash
     end
 
@@ -204,4 +203,3 @@ after_initialize do
     end
  
 end
-


### PR DESCRIPTION
Joomla (and Kunena forum) uses 3 different methods of hashing passwords.

- Original scheme is hash:salt where hash is MD5(password + salt)
- Joomla 2.5 uses the same scheme as Wordpress (passwords beginning $P$)
- Joomla 3.2 uses PhPass and bcrypt (passwords beginning $2y$